### PR TITLE
Delete 'os' matrix. It is not needed at all.

### DIFF
--- a/.github/workflows/rpm-check.yaml
+++ b/.github/workflows/rpm-check.yaml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["fedora", "gpu-fedora", "c9s", "c10s"]
         include:
           - os: "fedora"
             context: "Fedora"


### PR DESCRIPTION
We need whole include definitions.

In case of 'os' is defined, then only one 'gpu-fedora' is run.